### PR TITLE
Issue 67/enable completion and chat completion for other llms

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,3 +14,5 @@ services:
     ports:
       - 8080:8080
       - 8081:8081
+      # port for llama.cpp-python server to work with local LLMs
+      - 8000:8000

--- a/lib/openai_ex.ex
+++ b/lib/openai_ex.ex
@@ -8,7 +8,7 @@ defmodule OpenaiEx do
   making it easy to understand and reuse existing documentation and code.
   """
   @enforce_keys [:token]
-  defstruct token: nil, organization: nil, beta: nil
+  defstruct token: nil, organization: nil, beta: nil, base_url: "https://api.openai.com/v1"
 
   @doc """
   Creates a new OpenaiEx struct with the specified token and organization.
@@ -41,6 +41,10 @@ defmodule OpenaiEx do
   @doc false
   def with_assistants_beta(openai = %OpenaiEx{}) do
     openai |> Map.put(:beta, "assistants=v1")
+  end
+
+  def with_base_url(openai = %OpenaiEx{}, base_url) do
+    openai |> Map.put(:base_url, base_url)
   end
 
   @doc false

--- a/lib/openai_ex/http.ex
+++ b/lib/openai_ex/http.ex
@@ -1,8 +1,6 @@
 defmodule OpenaiEx.Http do
   @moduledoc false
 
-  @base_url "https://api.openai.com/v1"
-
   @doc false
   def headers(openai = %OpenaiEx{}) do
     base = [{"Authorization", "Bearer #{openai.token}"}]
@@ -23,7 +21,7 @@ defmodule OpenaiEx.Http do
   def post(openai = %OpenaiEx{}, url, multipart: multipart) do
     :post
     |> Finch.build(
-      @base_url <> url,
+      openai.base_url <> url,
       headers(openai) ++
         [
           {"Content-Type", Multipart.content_type(multipart, "multipart/form-data")},
@@ -50,7 +48,7 @@ defmodule OpenaiEx.Http do
   def build_post(openai = %OpenaiEx{}, url, json: json) do
     :post
     |> Finch.build(
-      @base_url <> url,
+      openai.base_url <> url,
       headers(openai) ++ [{"Content-Type", "application/json"}],
       Jason.encode_to_iodata!(json)
     )
@@ -70,20 +68,20 @@ defmodule OpenaiEx.Http do
   @doc false
   def get(openai = %OpenaiEx{}, url) do
     :get
-    |> Finch.build(@base_url <> url, headers(openai))
+    |> Finch.build(openai.base_url <> url, headers(openai))
     |> finch_run()
   end
 
   def get_no_decode(openai = %OpenaiEx{}, url) do
     :get
-    |> Finch.build(@base_url <> url, headers(openai))
+    |> Finch.build(openai.base_url <> url, headers(openai))
     |> finch_run_no_decode()
   end
 
   @doc false
   def delete(openai = %OpenaiEx{}, url) do
     :delete
-    |> Finch.build(@base_url <> url, headers(openai))
+    |> Finch.build(openai.base_url <> url, headers(openai))
     |> finch_run()
   end
 

--- a/notebooks/completions.livemd
+++ b/notebooks/completions.livemd
@@ -15,7 +15,14 @@ alias OpenaiEx.Completion
 ## Model Choices
 
 ```elixir
-openai = System.fetch_env!("LB_OPENAI_API_KEY") |> OpenaiEx.new()
+openai =
+  System.fetch_env!("LB_OPENAI_API_KEY")
+  |> OpenaiEx.new()
+
+# uncomment the line at the end of this block comment when working with a local LLM with a 
+# proxy such as llama.cpp-python in the example below, our development livebook server is 
+# running in a docker dev container while the local llm is running on the host machine
+# |> OpenaiEx.with_base_url("http://host.docker.internal:8000/v1")
 ```
 
 ```elixir
@@ -138,3 +145,5 @@ Create the form for the streaming completion API, and use it.
 ```elixir
 create_form.("## Streaming Chatbot", completion_stream)
 ```
+
+<!-- livebook:{"offset":3587,"stamp":{"token":"XCP.68_LJbeUk6F4BpQA1Wzojpg0rTxRlhSNCl7VPR97rQ8BkiJDowZdc0TIsCOJsURS-er1oOcekzNDlnsglBaG3OS3aJlG0TKbqYLRNjvLcHaKXv66lRgW6y8","version":2}} -->

--- a/notebooks/dlai_orderbot.livemd
+++ b/notebooks/dlai_orderbot.livemd
@@ -22,7 +22,14 @@ In this notebook, you will explore how you can utilize the chat format to have e
 ### Setup
 
 ```elixir
-openai = System.fetch_env!("LB_OPENAI_API_KEY") |> OpenaiEx.new()
+openai =
+  System.fetch_env!("LB_OPENAI_API_KEY")
+  |> OpenaiEx.new()
+
+# uncomment the line at the end of this block comment when working with a local LLM with a 
+# proxy such as llama.cpp-python in the example below, our development livebook server is 
+# running in a docker dev container while the local llm is running on the host machine
+# |> OpenaiEx.with_base_url("http://host.docker.internal:8000/v1")
 ```
 
 ```elixir
@@ -166,3 +173,5 @@ Kino.listen(
   end
 )
 ```
+
+<!-- livebook:{"offset":5189,"stamp":{"token":"XCP.BW4jh9R3XOcYacfW9G9Cws2KPP7-LFcjgbrzhAlTL9c9JwldGdePtKTuDQlIe4lpb-3bir6XzqgOk4t4qtAL9CxI9AKY72X4sqAYci71c2OoUpenaB3XeDk","version":2}} -->


### PR DESCRIPTION
i have parameterized the base url for the api.

without any other changes, this now works for non-streaming completions and chat completions with  the`llama.cpp-python` in server mode.