### PR TITLE
Fix exception when Logging warning

### DIFF
--- a/lib/openai_ex/http_sse.ex
+++ b/lib/openai_ex/http_sse.ex
@@ -59,7 +59,7 @@ defmodule OpenaiEx.HttpSse do
         {tokens, next_acc} = tokenize_data(evt_data, acc)
         {[tokens], {next_acc, ref, task}}
 
-      {:done, ^ref} when acc = "data: [DONE]" ->
+      {:done, ^ref} when acc == "data: [DONE]" ->
         {:halt, {acc, ref, task}}
       
       {:done, ^ref} ->

--- a/lib/openai_ex/http_sse.ex
+++ b/lib/openai_ex/http_sse.ex
@@ -60,7 +60,7 @@ defmodule OpenaiEx.HttpSse do
         {[tokens], {next_acc, ref, task}}
 
       {:done, ^ref} ->
-        if acc != "", do: Logger.warning(inspect(Jason.decode!(acc)))
+        if acc != "", do: Logger.warning(%{message: "Unexpected value in sse 'acc' after ':done' event received", value: acc})
         {:halt, {acc, ref, task}}
 
       {:canceled, ^ref} ->

--- a/lib/openai_ex/http_sse.ex
+++ b/lib/openai_ex/http_sse.ex
@@ -59,6 +59,9 @@ defmodule OpenaiEx.HttpSse do
         {tokens, next_acc} = tokenize_data(evt_data, acc)
         {[tokens], {next_acc, ref, task}}
 
+      {:done, ^ref} when acc = "data: [DONE]" ->
+        {:halt, {acc, ref, task}}
+      
       {:done, ^ref} ->
         if acc != "", do: Logger.warning(%{message: "Unexpected value in sse 'acc' after ':done' event received", value: acc})
         {:halt, {acc, ref, task}}


### PR DESCRIPTION
The following exception occurs every time the client encounters the OpenAI Chat completion SSE event `data: [DONE]`.

```elixir
** (exit) an exception was raised:
    ** (Jason.DecodeError) unexpected byte at position 0: 0x64 ("d")
        (jason 1.4.1) lib/jason.ex:92: Jason.decode!/2
        (openai_ex 0.5.8) lib/openai_ex/http_sse.ex:63: OpenaiEx.HttpSse.next_sse/1
        (elixir 1.16.2) lib/stream.ex:1626: Stream.do_resource/5
        (elixir 1.16.2) lib/stream.ex:943: Stream.do_transform/5
        (elixir 1.16.2) lib/stream.ex:1052: Stream.do_transform_inner_enum/7
```

This happens as the value in the `acc` is the above string which is not a valid JSON.

```elixir
  defp next_sse({acc, ref, task}) do
    receive do
      {:chunk, {:data, evt_data}, ^ref} ->
        {tokens, next_acc} = tokenize_data(evt_data, acc)
        {[tokens], {next_acc, ref, task}}

      {:done, ^ref} ->
       # >>>>>>>>>>>>>>>>>>> this call fails
        if acc != "", do: Logger.warning(inspect(Jason.decode!(acc)))
        {:halt, {acc, ref, task}}

      {:canceled, ^ref} ->
        Logger.info("Request canceled by user")
        {:halt, {acc, ref, task}}
    end
  end
```

The PR changes the above call with:

```elixir
defp next_sse({acc, ref, task}) do
    receive do
      {:chunk, {:data, evt_data}, ^ref} ->
        {tokens, next_acc} = tokenize_data(evt_data, acc)
        {[tokens], {next_acc, ref, task}}

      {:done, ^ref} when acc == "data: [DONE]" ->
        {:halt, {acc, ref, task}}
      
      {:done, ^ref} ->
        if acc != "", do: Logger.warning(%{message: "Unexpected value in sse 'acc' after ':done' event received", value: acc})
        {:halt, {acc, ref, task}}

      {:canceled, ^ref} ->
        Logger.info("Request canceled by user")
        {:halt, {acc, ref, task}}
    end
  end
```