### PR TITLE
Fix #100

### DIFF
--- a/lib/openai_ex/http_finch.ex
+++ b/lib/openai_ex/http_finch.ex
@@ -79,4 +79,6 @@ defmodule OpenaiEx.Http.Finch do
   end
 
   def to_error(:timeout, request), do: {:error, Error.api_timeout_error(request)}
+  def to_error(:closed, request), do: {:error, Error.api_connection_error("Connection closed.", request)}
+  def to_error(reason, request), do: {:error, Error.api_connection_error(reason, request)}
 end


### PR DESCRIPTION
**Context**
Linked issue: https://github.com/restlessronin/openai_ex/issues/100

When API experience latency and increased error rates, from time to time there is an error related closed connection happens.

**Solution**
1. To fix "no function clause matching OpenaiEx.Http.Finch.to_error/2" in this commit you find an addition clause for the error building mechanism
2. Also, there is a default function clause so other developers can can catch errors in a regular way and do not mess with the "try catch" statements.