### PR TITLE
Restore completions API

### DIFF
--- a/lib/openai_ex/completion.ex
+++ b/lib/openai_ex/completion.ex
@@ -2,6 +2,7 @@ defmodule OpenaiEx.Completion do
   @moduledoc """
   This module provides an implementation of the OpenAI completions API. The API reference can be found at https://platform.openai.com/docs/api-reference/completions.
   """
+  alias OpenaiEx.{Http, HttpSse}
 
   @api_fields [
     :model,
@@ -54,18 +55,23 @@ defmodule OpenaiEx.Completion do
   A map containing the API response.
   See https://platform.openai.com/docs/api-reference/completions/create for more information.
   """
+  def create!(openai = %OpenaiEx{}, completion = %{}, stream: true) do
+    openai |> create(completion, stream: true) |> Http.bang_it!()
+  end
+
   def create(openai = %OpenaiEx{}, completion = %{}, stream: true) do
     ep = Map.get(openai, :_ep_path_mapping).(@ep_url)
 
     openai
-    |> OpenaiEx.HttpSse.post(ep,
-      json: completion |> Map.take(@api_fields) |> Map.put(:stream, true)
-    )
+    |> HttpSse.post(ep, json: completion |> Map.take(@api_fields) |> Map.put(:stream, true))
+  end
+
+  def create!(openai = %OpenaiEx{}, completion = %{}) do
+    openai |> create(completion) |> Http.bang_it!()
   end
 
   def create(openai = %OpenaiEx{}, completion = %{}) do
     ep = Map.get(openai, :_ep_path_mapping).(@ep_url)
-
-    openai |> OpenaiEx.Http.post(ep, json: completion |> Map.take(@api_fields))
+    openai |> Http.post(ep, json: completion |> Map.take(@api_fields))
   end
 end

--- a/lib/openai_ex/completion.ex
+++ b/lib/openai_ex/completion.ex
@@ -1,0 +1,71 @@
+defmodule OpenaiEx.Completion do
+  @moduledoc """
+  This module provides an implementation of the OpenAI completions API. The API reference can be found at https://platform.openai.com/docs/api-reference/completions.
+  """
+
+  @api_fields [
+    :model,
+    :prompt,
+    :best_of,
+    :echo,
+    :frequency_penalty,
+    :logit_bias,
+    :logprobs,
+    :max_tokens,
+    :n,
+    :presence_penalty,
+    :stop,
+    :suffix,
+    :temperature,
+    :top_p,
+    :user
+  ]
+
+  @doc """
+  Creates a new completion request with the given arguments.
+  ## Arguments
+  - `args`: A list of key-value pairs, or a map, representing the fields of the completion request.
+  ## Returns
+  A map containing the fields of the completion request.
+  The `:model` field is required.
+  Example usage:
+      iex> _request = OpenaiEx.Completion.new(model: "davinci")
+      %{model: "davinci"}
+      iex> _request = OpenaiEx.Completion.new(%{model: "davinci"})
+      %{model: "davinci"}
+  """
+
+  def new(args = [_ | _]) do
+    args |> Enum.into(%{}) |> new()
+  end
+
+  def new(args = %{model: _}) do
+    args |> Map.take(@api_fields)
+  end
+
+  @ep_url "/completions"
+
+  @doc """
+  Calls the completion 'create' endpoint.
+  ## Arguments
+  - `openai`: The OpenAI configuration.
+  - `completion`: The completion request, as a map with keys corresponding to the API fields.
+  ## Returns
+  A map containing the API response.
+  See https://platform.openai.com/docs/api-reference/completions/create for more information.
+  """
+  def create(openai = %OpenaiEx{}, completion = %{}, stream: true) do
+    ep = Map.get(openai, :_ep_path_mapping).(@ep_url)
+
+    openai
+    |> OpenaiEx.HttpSse.post(ep,
+      json: completion |> Map.take(@api_fields) |> Map.put(:stream, true)
+    )
+  end
+
+  def create(openai = %OpenaiEx{}, completion = %{}) do
+    ep = Map.get(openai, :_ep_path_mapping).(@ep_url)
+
+    openai |> OpenaiEx.Http.post(ep, json: completion |> Map.take(@api_fields))
+  end
+end

--- a/notebooks/completions.livemd
+++ b/notebooks/completions.livemd
@@ -1,0 +1,156 @@
+<!-- livebook:{"app_settings":{"access_type":"public","show_source":true,"slug":"completion"}} -->
+
+# Completions Bot
+
+```elixir
+Mix.install([
+  {:openai_ex, "~> 0.7.0"},
+  {:kino, "~> 0.13.1"}
+])
+
+alias OpenaiEx
+alias OpenaiEx.Completion
+```
+
+## Deprecation Notice
+
+Note that OpenAI has deprecated the models that use the Completion API. The newer models all use the Chat Completion API. As such, this livebook will **stop working** when the models are discontinued.
+
+It is still being left in the documentation in case people want to use it with non OpenAI models through an OpenAI API proxy.
+
+## Model Choices
+
+```elixir
+openai =
+  System.fetch_env!("LB_OPENAI_API_KEY")
+  |> OpenaiEx.new()
+
+# uncomment the line at the end of this block comment when working with a local LLM with a 
+# proxy such as llama.cpp-python in the example below, our development livebook server is 
+# running in a docker dev container while the local llm is running on the host machine
+# |> OpenaiEx.with_base_url("http://host.docker.internal:8000/v1")
+```
+
+```elixir
+comp_models = [
+  "text-davinci-003",
+  "text-davinci-002",
+  "text-curie-001",
+  "text-babbage-001",
+  "text-ada-001"
+]
+```
+
+## Normal Completion
+
+This function calls the completion API and renders the result in the given Kino frame.
+
+```elixir
+completion = fn model, prompt, max_tokens, temperature, last_frame ->
+  text =
+    openai
+    |> Completion.create(%{
+      model: model,
+      prompt: prompt,
+      max_tokens: max_tokens,
+      temperature: temperature
+    })
+    |> Map.get("choices")
+    |> Enum.at(0)
+    |> Map.get("text")
+
+  Kino.Frame.render(last_frame, Kino.Markdown.new("**Bot** #{text}"))
+  text
+end
+```
+
+## Streaming Completion
+
+This function calls the streaming completion API and continuously updates the Kino frame with the latest tokens
+
+```elixir
+completion_stream = fn model, prompt, max_tokens, temperature, last_frame ->
+  stream =
+    openai
+    |> Completion.create(
+      %{
+        model: model,
+        prompt: prompt,
+        max_tokens: max_tokens,
+        temperature: temperature
+      },
+      stream: true
+    )
+
+  token_stream =
+    stream.body_stream
+    |> Stream.flat_map(& &1)
+    |> Stream.map(fn %{data: data} ->
+      data |> Map.get("choices") |> Enum.at(0) |> Map.get("text")
+    end)
+
+  token_stream
+  |> Enum.reduce("", fn out, acc ->
+    next = acc <> out
+    Kino.Frame.render(last_frame, Kino.Markdown.new("**Bot** #{next}"))
+    next
+  end)
+end
+```
+
+## Create a Form UI
+
+This is a function to create a Form UI that can be used to call the completion API. The 2nd parameter determines whether the normal or streaming API is called.
+
+```elixir
+create_form = fn title, completion_fn ->
+  chat_frame = Kino.Frame.new()
+  last_frame = Kino.Frame.new()
+
+  Kino.Frame.render(chat_frame, Kino.Markdown.new(title))
+
+  inputs = [
+    model: Kino.Input.select("Model", comp_models |> Enum.map(fn x -> {x, x} end)),
+    max_tokens: Kino.Input.number("Max Tokens", default: 400),
+    temperature: Kino.Input.number("Temperature", default: 1),
+    prompt: Kino.Input.textarea("Prompt")
+  ]
+
+  form = Kino.Control.form(inputs, submit: "Send", reset_on_submit: [:prompt])
+
+  Kino.listen(
+    form,
+    fn %{
+         data: %{
+           prompt: prompt,
+           model: model,
+           max_tokens: max_tokens,
+           temperature: temperature
+         }
+       } ->
+      Kino.Frame.render(chat_frame, Kino.Markdown.new(title))
+      Kino.Frame.append(chat_frame, Kino.Markdown.new("**Me** #{prompt}"))
+
+      completion_fn.(model, prompt, max_tokens, temperature, last_frame)
+    end
+  )
+
+  Kino.Layout.grid([chat_frame, last_frame, form], boxed: true, gap: 16)
+end
+```
+
+### Normal Chatbot
+
+Create the Form for the non-streaming completion API and use it.
+
+```elixir
+create_form.("## Completion Chatbot", completion)
+```
+
+### Streaming Chatbot
+
+Create the form for the streaming completion API, and use it.
+
+```elixir
+create_form.("## Streaming Chatbot", completion_stream)
+```

--- a/notebooks/completions.livemd
+++ b/notebooks/completions.livemd
@@ -49,7 +49,7 @@ This function calls the completion API and renders the result in the given Kino 
 completion = fn model, prompt, max_tokens, temperature, last_frame ->
   text =
     openai
-    |> Completion.create(%{
+    |> Completion.create!(%{
       model: model,
       prompt: prompt,
       max_tokens: max_tokens,
@@ -72,7 +72,7 @@ This function calls the streaming completion API and continuously updates the Ki
 completion_stream = fn model, prompt, max_tokens, temperature, last_frame ->
   stream =
     openai
-    |> Completion.create(
+    |> Completion.create!(
       %{
         model: model,
         prompt: prompt,

--- a/test/openai_ex_test.exs
+++ b/test/openai_ex_test.exs
@@ -1,6 +1,7 @@
 defmodule OpenaiExTest do
   use ExUnit.Case
   doctest OpenaiEx.Chat.Completions
+  doctest OpenaiEx.Completion
   doctest OpenaiEx.ChatMessage
   doctest OpenaiEx.Embeddings
   doctest OpenaiEx.Images.Generate


### PR DESCRIPTION
Restores `OpenaiEx.Completions` API as outlined in #102, and the corresponding livebook.

The code here is just what was in the original module prior to its removal. I tested with `meta-llama/llama-3.1-405b` on OpenRouter. Both normal and streaming completions work, and the module has feature parity with the Python library, so I think rewriting it is unnecessary.

Anyways, thanks so much ^^ your code is a pleasure to work with.