### PR TITLE
fix: pass exception instead of tuple to raise

### DIFF
--- a/lib/openai_ex/http_sse.ex
+++ b/lib/openai_ex/http_sse.ex
@@ -120,10 +120,19 @@ defmodule OpenaiEx.HttpSse do
     fn acc ->
       try do:
             (case acc do
-               {:exception, :timeout} -> raise(Error.sse_timeout_error())
-               {:exception, :canceled} -> raise(Error.sse_user_cancellation())
-               {:exception, {:stream_error, exception}} -> raise(Client.to_error(exception, nil))
-               _ -> :ok
+               {:exception, :timeout} ->
+                 raise(Error.sse_timeout_error())
+
+               {:exception, :canceled} ->
+                 raise(Error.sse_user_cancellation())
+
+               {:exception, {:stream_error, exception}} ->
+                 case Client.to_error(exception, nil) do
+                   {:error, exception} -> raise(exception)
+                 end
+
+               _ ->
+                 :ok
              end),
           after: Task.shutdown(task)
     end


### PR DESCRIPTION
This PR fixes an issue I was seeing the following in my logs:

```
** (ArgumentError) raise/1 and reraise/2 expect a module name, string or exception as the first argument, got: {:error, %OpenaiEx.Error{status_code: nil, name: nil, message: "Request timed out.", body: nil, code: nil, param: nil, type: nil, request_id: nil, request: nil, kind: :api_timeout_error}}
    (openai_ex 0.9.14) lib/openai_ex/http_sse.ex:125: anonymous fn/2 in OpenaiEx.HttpSse.end_stream/1
```

`OpenaiEx.Http.Finch.to_error/2` returns a `{:error, exception}` tuple, and this was getting passed to `raise/1` directly. However, `raise/1` expects a string or exception as its first argument, so the return value of `to_error/2` has to be unwrapped first.